### PR TITLE
Set non blocking

### DIFF
--- a/src/bloomd/networking.c
+++ b/src/bloomd/networking.c
@@ -41,6 +41,9 @@
 /**
  * Default listen backlog size for
  * our UNIX listener.
+ * Because TCP backlog could actually contain already estabilished connections,
+ * and actual buffer for pending TCP connections is much larger it is make sense to have
+ * a different backlog for unix socket. Probably it make sense to just use the SOMAXCONN value here.
  */
 #define UNIX_BACKLOG_SIZE 128
 


### PR DESCRIPTION
Golang client uses non-blocking connection while bloomd server initializes a blocking socket. This fix adds a O_NONBLOCK property to bloomd unix domain socket. In addition, BACKLOG_SIZE were increased for bloomd socket listener so client pool initialization can afford more initial connections.